### PR TITLE
Field doesn't exists in documentation!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Code sample
 ===========
 
-[Guia de integração com Express Checkout](https://www.paypal-brasil.com.br/x/tutoriais/guia-rapido-de-integracao-com-express-checkout/)
+[Guia de integração com Express Checkout](https://www.paypal-brasil.com.br/desenvolvedores/tutorial/guia-de-integracao-rapida-usando-express-checkout/)

--- a/setExpressCheckout.php
+++ b/setExpressCheckout.php
@@ -44,7 +44,7 @@ $requestNvp = array(
     'L_PAYMENTREQUEST_0_DESC0' => 'Produto A – 110V',
     'L_PAYMENTREQUEST_0_AMT0' => '11.00',
     'L_PAYMENTREQUEST_0_QTY0' => '1',
-    'L_PAYMENTREQUEST_0_ITEMAMT' => '11.00',
+   
     'L_PAYMENTREQUEST_0_NAME1' => 'Item B',
     'L_PAYMENTREQUEST_0_DESC1' => 'Produto B – 220V',
     'L_PAYMENTREQUEST_0_AMT1' => '11.00',


### PR DESCRIPTION
L_PAYMENTREQUEST_0_ITEMAMT doesn't exists in documentation!

Documentation https://developer.paypal.com/webapps/developer/docs/classic/api/merchant/SetExpressCheckout_API_Operation_NVP/

PAYMENTREQUEST_n_ITEMAMT exists and use PAYMENTREQUEST_0_ITEMAMT, but  L_PAYMENTREQUEST_0_ITEMAMT or L_PAYMENTREQUEST_n_ITEMAMT doesn't exists.

And fixed link!

https://www.paypal-brasil.com.br/desenvolvedores/tutorial/guia-de-integracao-rapida-usando-express-checkout/
